### PR TITLE
Upgrade to MCP spec 2025-11-25 (SDK 1.27.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This document provides comprehensive guidance for AI assistants working with the
 ## Project Overview
 
 **Name**: Unconventional Thinking Server (unreasnable-thinker-server)
-**Version**: 0.2.0
-**Type**: MCP (Model Context Protocol) Server
+**Version**: 0.3.0
+**Type**: MCP (Model Context Protocol) Server — spec 2025-11-25, SDK 1.27.1
 **Purpose**: A context-efficient tool for generating and tracking unconventional, boundary-breaking problem-solving thoughts
 
 This is a TypeScript-based MCP server that implements an unconventional thinking system optimized for **context space savings** based on Anthropic's latest MCP architecture patterns. The server demonstrates recommended patterns for reducing context overhead by 98.7%.
@@ -60,7 +60,7 @@ Storage format: JSON object with thought IDs as keys in `.thoughts/thoughts.json
 
 ### Dependencies
 - **Runtime**: Node.js with ES2022 target
-- **MCP SDK**: `@modelcontextprotocol/sdk@0.6.0` - Core protocol implementation
+- **MCP SDK**: `@modelcontextprotocol/sdk@1.27.1` - Core protocol implementation (spec 2025-11-25)
 - **TypeScript**: `^5.3.3` - Type safety and compilation
 - **Node Types**: `@types/node@^20.11.24` - Node.js type definitions
 
@@ -85,10 +85,10 @@ This makes the compiled binary executable for direct invocation.
 ```typescript
 {
   name: "unconventional-thinking-server",
-  version: "0.2.0",
+  version: "0.3.0",
   capabilities: {
-    tools: {},      // Provides 3 tools
-    resources: {}   // Provides thought:// resources
+    tools: { listChanged: true },  // Provides 3 tools; notifies clients on changes
+    resources: {}                  // Provides thought:// resources
   }
 }
 ```
@@ -279,9 +279,9 @@ When modifying or extending this codebase:
 - Use optional chaining for optional fields (`thought.branchId?.`)
 
 ### 6. Versioning
-- Current version: 0.2.0 (context-efficient refactor)
+- Current version: 0.3.0 (MCP spec 2025-11-25 upgrade)
 - Update version in **both** package.json and server initialization
-- Version 0.2.0 marks the transition to context-efficient architecture
+- Version 0.3.0 adds tool titles, annotations, outputSchema, structuredContent, resource_link
 
 ## Common Development Tasks
 
@@ -383,7 +383,18 @@ With 100 thoughts (500 chars each):
 
 ## Version History
 
-- **v0.2.0** (Current) - Context-efficient refactor
+- **v0.3.0** (Current) - MCP spec 2025-11-25 upgrade
+  - Updated `@modelcontextprotocol/sdk` from `0.6.0` to `1.27.1`
+  - Added `title` to every tool for human-readable display in client UIs
+  - Added `annotations` to every tool (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+  - Added `outputSchema` to every tool to validate structured results
+  - Tools now return `structuredContent` alongside text for typed machine-readable output
+  - `generate_unreasonable_thought` and `branch_thought` return `resource_link` content items instead of URI-in-JSON-text
+  - Tool execution errors (thought not found) now use `isError: true` instead of protocol-level `McpError`
+  - Added `listChanged: true` to the `tools` capability declaration
+  - `branch_thought` `direction` parameter is now enum-typed
+
+- **v0.2.0** - Context-efficient refactor
   - Added Resources API for on-demand content loading
   - Implemented server-side filtering with `search_thoughts`
   - Changed tools to return metadata + URIs only
@@ -413,6 +424,6 @@ With 100 thoughts (500 chars each):
 
 ---
 
-**Last Updated**: 2025-11-24
-**Document Version**: 1.0
-**Codebase Version**: 0.2.0
+**Last Updated**: 2026-02-26
+**Document Version**: 2.0
+**Codebase Version**: 0.3.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Unconventional Thinking Server (v0.2.0)
+# Unconventional Thinking Server (v0.3.0)
 
 A context-efficient MCP server for bold, unconventional, and boundary-breaking problem-solving.
 
 This is a TypeScript-based MCP server that implements an unconventional thinking system optimized for **context space savings** based on Anthropic's latest MCP architecture patterns. It generates and tracks creative solutions to problems while maintaining efficiency.
+
+> **MCP spec 2025-11-25 compliant** — uses `@modelcontextprotocol/sdk` v1.27.1 with tool `title`, `annotations`, `outputSchema`, `structuredContent` responses, and `resource_link` content type.
 
 ## Architecture: Context-Saving Design
 
@@ -32,21 +34,30 @@ This server demonstrates Anthropic's **recommended patterns for reducing context
 
 ## Features
 
-### Tools (All Context-Efficient)
-- `generate_unreasonable_thought` - Generate new unconventional thoughts
-  - Returns metadata + resource URI, not full content
+### Tools (All Context-Efficient, MCP spec 2025-11-25)
+
+Each tool now includes:
+- `title` — human-readable display name shown in client UIs
+- `annotations` — behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- `outputSchema` — JSON Schema describing the structured result
+- `structuredContent` in responses — machine-readable output conforming to the schema
+- `resource_link` content items — explicit links clients can subscribe to or fetch
+
+---
+
+- `generate_unreasonable_thought` — Generate new unconventional thoughts
+  - Returns `resource_link` + `structuredContent`, not raw text blobs
   - Can build upon or rebel against previous thoughts
   - Full thought content available via Resources API
 
-- `branch_thought` - Create new branches of thinking
-  - Supports directions: more extreme, opposite, tangential
-  - Returns only branch metadata for efficiency
+- `branch_thought` — Create new branches of thinking
+  - Supports directions: `more_extreme`, `opposite`, `tangential` (now enum-typed)
+  - Returns `resource_link` + `structuredContent` for the new branch
 
-- `search_thoughts` - **NEW: Efficient metadata search**
+- `search_thoughts` — Efficient metadata search
   - Filters by branchId, isRebellion, challengesAssumption
-  - Returns only matching IDs and metadata
+  - Returns `structuredContent` with typed count + thoughts array
   - Includes limit parameter to control result size
-  - Demonstrates server-side filtering pattern
 
 ### Resources (On-Demand Content Loading)
 - Each thought available as a resource: `thought://[thoughtId]`
@@ -125,11 +136,11 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 ```
 Claude: Generate an unreasonable thought about scaling problems
 → Tool: generate_unreasonable_thought("scaling problems")
-← Returns: thoughtId, resourceUri, metadata
+← Returns: resource_link (thought://...) + structuredContent { thoughtId, isRebellion, ... }
 
 Claude: What are all the rebellious thoughts?
 → Tool: search_thoughts(isRebellion=true, limit=5)
-← Returns: 5 matching thought IDs with URIs (minimal context)
+← Returns: structuredContent { count, thoughts: [...metadata] }
 
 Claude: I need to see the full content of thought_xyz
 → Resource: Read thought://thought_xyz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreasnable-thinker-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A detailed tool for bold, unconventional, and boundary-breaking problem-solving.",
   "private": true,
   "type": "module",
@@ -17,7 +17,7 @@
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.6.0"
+    "@modelcontextprotocol/sdk": "1.27.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,11 +45,14 @@ function saveThoughts(thoughts: { [id: string]: Thought }) {
 const server = new Server(
   {
     name: "unconventional-thinking-server",
-    version: "0.2.0",
+    version: "0.3.0",
   },
   {
     capabilities: {
-      tools: {},
+      // listChanged: true signals the server can notify clients when tools change
+      tools: {
+        listChanged: true,
+      },
       resources: {},
     },
   }
@@ -60,70 +63,164 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "generate_unreasonable_thought",
-        description: "Generate a new unreasonable thought that challenges conventional thinking. Efficiently creates thoughts without loading full context.",
+        // title: human-readable display name (MCP spec 2025-11-25)
+        title: "Generate Unreasonable Thought",
+        description:
+          "Generate a new unreasonable thought that challenges conventional thinking. Efficiently creates thoughts without loading full context.",
+        // annotations: hints about tool behaviour for clients and safety UIs (MCP spec 2025-11-25)
+        annotations: {
+          readOnlyHint: false,       // writes a new thought to storage
+          destructiveHint: false,    // only adds data, never deletes
+          idempotentHint: false,     // each call produces a distinct thought
+          openWorldHint: false,      // operates only on local .thoughts storage
+        },
         inputSchema: {
           type: "object",
           properties: {
             problem: {
               type: "string",
-              description: "The problem or challenge to think unreasonably about"
+              description: "The problem or challenge to think unreasonably about",
             },
             previousThoughtId: {
               type: "string",
-              description: "Optional ID of a previous thought to build upon or rebel against"
+              description:
+                "Optional ID of a previous thought to build upon or rebel against",
             },
             forceRebellion: {
               type: "boolean",
-              description: "Force the thought to rebel against conventional wisdom"
-            }
+              description:
+                "Force the thought to rebel against conventional wisdom",
+            },
           },
-          required: ["problem"]
-        }
+          required: ["problem"],
+        },
+        // outputSchema: validates structuredContent returned by the tool (MCP spec 2025-11-25)
+        outputSchema: {
+          type: "object",
+          properties: {
+            thoughtId: {
+              type: "string",
+              description: "Unique identifier for the generated thought",
+            },
+            isRebellion: {
+              type: "boolean",
+              description:
+                "Whether the thought rebels against conventional wisdom",
+            },
+            challengesAssumption: {
+              type: "boolean",
+              description: "Whether the thought challenges core assumptions",
+            },
+            branchInfo: {
+              type: "string",
+              description: "Branch context for the thought",
+            },
+          },
+          required: ["thoughtId", "isRebellion", "challengesAssumption", "branchInfo"],
+        },
       },
       {
         name: "branch_thought",
-        description: "Create a new branch of thinking from an existing thought. Returns only metadata, not full content.",
+        title: "Branch a Thought",
+        description:
+          "Create a new branch of thinking from an existing thought. Returns only metadata, not full content.",
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
         inputSchema: {
           type: "object",
           properties: {
             thoughtId: {
               type: "string",
-              description: "ID of the thought to branch from"
+              description: "ID of the thought to branch from",
             },
             direction: {
               type: "string",
-              description: "Direction for the new branch (e.g. 'more_extreme', 'opposite', 'tangential')"
-            }
+              description:
+                "Direction for the new branch ('more_extreme', 'opposite', 'tangential')",
+              enum: ["more_extreme", "opposite", "tangential"],
+            },
           },
-          required: ["thoughtId", "direction"]
-        }
+          required: ["thoughtId", "direction"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            thoughtId: {
+              type: "string",
+              description: "Unique identifier for the new branched thought",
+            },
+            branchInfo: {
+              type: "string",
+              description: "Description of the branch relationship",
+            },
+            direction: {
+              type: "string",
+              description: "The branching direction applied",
+            },
+          },
+          required: ["thoughtId", "branchInfo", "direction"],
+        },
       },
       {
         name: "search_thoughts",
-        description: "Search for thought IDs by metadata. Returns only matching IDs and metadata, not full content. Enables efficient filtering.",
+        title: "Search Thoughts",
+        description:
+          "Search for thought IDs by metadata. Returns only matching IDs and metadata, not full content. Enables efficient filtering.",
+        annotations: {
+          readOnlyHint: true,    // only reads, never writes
+          openWorldHint: false,  // operates only on local .thoughts storage
+        },
         inputSchema: {
           type: "object",
           properties: {
             branchId: {
               type: "string",
-              description: "Optional branch ID to filter thoughts"
+              description: "Optional branch ID to filter thoughts",
             },
             isRebellion: {
               type: "boolean",
-              description: "Filter by rebellion status"
+              description: "Filter by rebellion status",
             },
             challengesAssumption: {
               type: "boolean",
-              description: "Filter by assumption-challenging status"
+              description: "Filter by assumption-challenging status",
             },
             limit: {
               type: "number",
-              description: "Maximum number of results to return (default: 10)"
-            }
-          }
-        }
-      }
-    ]
+              description: "Maximum number of results to return (default: 10)",
+            },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            count: {
+              type: "number",
+              description: "Number of thoughts matching the filter",
+            },
+            thoughts: {
+              type: "array",
+              description: "List of matching thought metadata entries",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  isRebellion: { type: "boolean" },
+                  challengesAssumption: { type: "boolean" },
+                  branchId: { type: "string" },
+                  timestamp: { type: "number" },
+                },
+              },
+            },
+          },
+          required: ["count", "thoughts"],
+        },
+      },
+    ],
   };
 });
 
@@ -156,58 +253,88 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   }
 
   return {
-    contents: [{
-      uri,
-      mimeType: "application/json",
-      text: JSON.stringify(thought, null, 2),
-    }],
+    contents: [
+      {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify(thought, null, 2),
+      },
+    ],
   };
 });
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   switch (request.params.name) {
     case "generate_unreasonable_thought": {
-      const { problem, previousThoughtId, forceRebellion } = request.params.arguments as any;
+      const { problem, previousThoughtId, forceRebellion } =
+        request.params.arguments as any;
 
       const thoughtId = `thought_${Date.now()}`;
       const isRebellion = forceRebellion || Math.random() > 0.5;
 
       const thoughts = loadThoughts();
-      let branchId;
+      let branchId: string | undefined;
+
       if (previousThoughtId) {
         const previousThought = thoughts[previousThoughtId];
         if (!previousThought) {
-          throw new McpError(ErrorCode.InvalidParams, "Previous thought not found");
+          // Tool execution error: use isError rather than a protocol-level McpError
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Previous thought not found: ${previousThoughtId}`,
+              },
+            ],
+            isError: true,
+          };
         }
         branchId = previousThought.branchId;
       }
 
       const thought: Thought = {
         id: thoughtId,
-        content: generateUnreasonableThought(problem, previousThoughtId ? thoughts[previousThoughtId] : undefined),
+        content: generateUnreasonableThought(
+          problem,
+          previousThoughtId ? thoughts[previousThoughtId] : undefined
+        ),
         isRebellion,
         challengesAssumption: Math.random() > 0.3,
         branchFromThought: previousThoughtId,
         branchId,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       };
 
       thoughts[thoughtId] = thought;
       saveThoughts(thoughts);
 
-      // Return only essential metadata, not full content - saves context
+      const structured = {
+        thoughtId,
+        isRebellion: thought.isRebellion,
+        challengesAssumption: thought.challengesAssumption,
+        branchInfo: thought.branchId ? `Branch: ${thought.branchId}` : "Main branch",
+      };
+
+      // resource_link lets the client know it can directly fetch the full thought
+      // structuredContent provides typed output matching outputSchema (MCP spec 2025-11-25)
       return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            thoughtId,
-            resourceUri: `thought://${thoughtId}`,
-            isRebellion: thought.isRebellion,
-            challengesAssumption: thought.challengesAssumption,
-            branchInfo: thought.branchId ? `Branch: ${thought.branchId}` : "Main branch",
-            message: "Thought generated. Use resource URI to access full content."
-          }, null, 2)
-        }]
+        content: [
+          {
+            // resource_link: explicit link to the resource (MCP spec 2025-11-25)
+            type: "resource_link" as const,
+            uri: `thought://${thoughtId}`,
+            name: `Thought ${thoughtId}`,
+            description: `${thought.isRebellion ? "Rebellious" : "Conventional"} thought — read resource for full content`,
+            mimeType: "application/json",
+          },
+          {
+            // Text fallback with serialised structuredContent for backwards compatibility
+            type: "text" as const,
+            text: JSON.stringify(structured, null, 2),
+          },
+        ],
+        // structuredContent: machine-readable output conforming to outputSchema
+        structuredContent: structured,
       };
     }
 
@@ -217,7 +344,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const sourceThought = thoughts[thoughtId];
 
       if (!sourceThought) {
-        throw new McpError(ErrorCode.InvalidParams, "Source thought not found");
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Source thought not found: ${thoughtId}`,
+            },
+          ],
+          isError: true,
+        };
       }
 
       const newBranchId = `branch_${++branchCounter}`;
@@ -226,62 +361,84 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const thought: Thought = {
         id: newThoughtId,
         content: generateBranchedThought(sourceThought, direction),
-        isRebellion: direction === 'opposite',
+        isRebellion: direction === "opposite",
         challengesAssumption: true,
         branchFromThought: thoughtId,
         branchId: newBranchId,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       };
 
       thoughts[newThoughtId] = thought;
       saveThoughts(thoughts);
 
-      // Return only metadata - the full thought content stays in the resource
+      const structured = {
+        thoughtId: newThoughtId,
+        branchInfo: `New branch ${newBranchId} from thought ${thoughtId}`,
+        direction,
+      };
+
       return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            thoughtId: newThoughtId,
-            resourceUri: `thought://${newThoughtId}`,
-            branchInfo: `New branch ${newBranchId} from thought ${thoughtId}`,
-            direction,
-            message: "New thought branch created. Use resource URI to access full content."
-          }, null, 2)
-        }]
+        content: [
+          {
+            type: "resource_link" as const,
+            uri: `thought://${newThoughtId}`,
+            name: `Thought ${newThoughtId}`,
+            description: `Branched thought (${direction}) — read resource for full content`,
+            mimeType: "application/json",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(structured, null, 2),
+          },
+        ],
+        structuredContent: structured,
       };
     }
 
     case "search_thoughts": {
-      const { branchId, isRebellion, challengesAssumption, limit = 10 } = request.params.arguments as any || {};
+      const {
+        branchId,
+        isRebellion,
+        challengesAssumption,
+        limit = 10,
+      } = (request.params.arguments as any) || {};
       const thoughts = loadThoughts();
 
-      // Filter at the server level - don't send unfiltered data to Claude
+      // Filter at the server level — don't send unfiltered data to the model
       const filtered = Object.values(thoughts)
-        .filter(t => {
+        .filter((t) => {
           if (branchId && t.branchId !== branchId) return false;
-          if (isRebellion !== undefined && t.isRebellion !== isRebellion) return false;
-          if (challengesAssumption !== undefined && t.challengesAssumption !== challengesAssumption) return false;
+          if (isRebellion !== undefined && t.isRebellion !== isRebellion)
+            return false;
+          if (
+            challengesAssumption !== undefined &&
+            t.challengesAssumption !== challengesAssumption
+          )
+            return false;
           return true;
         })
         .sort((a, b) => b.timestamp - a.timestamp)
         .slice(0, limit);
 
-      // Return only metadata - IDs and resource URIs, not full content
+      const structured = {
+        count: filtered.length,
+        thoughts: filtered.map((t) => ({
+          id: t.id,
+          isRebellion: t.isRebellion,
+          challengesAssumption: t.challengesAssumption,
+          branchId: t.branchId || "main",
+          timestamp: t.timestamp,
+        })),
+      };
+
       return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            count: filtered.length,
-            thoughts: filtered.map(t => ({
-              id: t.id,
-              resourceUri: `thought://${t.id}`,
-              isRebellion: t.isRebellion,
-              challengesAssumption: t.challengesAssumption,
-              branchId: t.branchId || "main",
-              timestamp: t.timestamp
-            }))
-          }, null, 2)
-        }]
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(structured, null, 2),
+          },
+        ],
+        structuredContent: structured,
       };
     }
 
@@ -290,7 +447,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-function generateUnreasonableThought(problem: string, previousThought?: Thought): string {
+function generateUnreasonableThought(
+  problem: string,
+  previousThought?: Thought
+): string {
   const unreasonableApproaches = [
     `What if we completely eliminated the concept of ${problem}?`,
     `Imagine if ${problem} operated in reverse - what opportunities would that create?`,
@@ -299,10 +459,13 @@ function generateUnreasonableThought(problem: string, previousThought?: Thought)
     `How would an alien civilization with completely different logic solve ${problem}?`,
     `What if the opposite of "${problem}" is actually the better solution?`,
     `What if we scaled ${problem} up 1000x - what becomes possible?`,
-    `What if we removed all constraints from ${problem} - what changes?`
+    `What if we removed all constraints from ${problem} - what changes?`,
   ];
 
-  let thought = unreasonableApproaches[Math.floor(Math.random() * unreasonableApproaches.length)];
+  let thought =
+    unreasonableApproaches[
+      Math.floor(Math.random() * unreasonableApproaches.length)
+    ];
 
   if (previousThought) {
     thought = `Building on: ${previousThought.content}\n\nNew angle: ${thought}`;
@@ -311,24 +474,29 @@ function generateUnreasonableThought(problem: string, previousThought?: Thought)
   return thought;
 }
 
-function generateBranchedThought(sourceThought: Thought, direction: string): string {
+function generateBranchedThought(
+  sourceThought: Thought,
+  direction: string
+): string {
   switch (direction) {
-    case 'more_extreme':
-      return `Taking it further: ${sourceThought.content}\n→ What if we amplify this 1000x? What becomes possible?`;
-    case 'opposite':
+    case "more_extreme":
+      return `Taking it further: ${sourceThought.content}\n\u2192 What if we amplify this 1000x? What becomes possible?`;
+    case "opposite":
       return `Complete reversal: If the opposite of "${sourceThought.content}" were true, what would that imply?`;
-    case 'tangential':
-      return `Unexpected connection: ${sourceThought.content}\n→ How does this apply to a completely different domain?`;
+    case "tangential":
+      return `Unexpected connection: ${sourceThought.content}\n\u2192 How does this apply to a completely different domain?`;
     default:
-      return `Building on: ${sourceThought.content}\n→ Taking this in a new direction...`;
+      return `Building on: ${sourceThought.content}\n\u2192 Taking this in a new direction...`;
   }
 }
 
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Unconventional Thinking MCP server (v0.2.0) running on stdio");
-  console.error("Context-efficient architecture: Returns metadata, stores content in resources");
+  console.error("Unconventional Thinking MCP server (v0.3.0) running on stdio");
+  console.error(
+    "MCP spec 2025-11-25: tool titles, annotations, outputSchema, structuredContent, resource_link"
+  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- **Bump SDK**: `@modelcontextprotocol/sdk` `0.6.0` → `1.27.1` (current protocol version 2025-11-25)
- **Tool `title`**: All three tools now have a human-readable `title` field for display in client UIs
- **Tool `annotations`**: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` on every tool — lets clients show safety context to users
- **Tool `outputSchema`**: JSON Schema describing each tool's structured output, enabling client-side validation
- **`structuredContent`** in responses: every tool returns machine-readable `structuredContent` alongside the text fallback, conforming to its `outputSchema`
- **`resource_link` content type**: `generate_unreasonable_thought` and `branch_thought` now return a `resource_link` item pointing at `thought://…` instead of encoding the URI inside a JSON string — clients can directly subscribe to or fetch the resource
- **Proper error handling**: "thought not found" during tool execution returns `isError: true` (tool execution error) rather than a protocol-level `McpError`
- **`listChanged: true`** capability: server declares it can notify clients when the tool list changes
- **Enum-typed `direction`**: `branch_thought` `direction` parameter is now an enum (`more_extreme`, `opposite`, `tangential`)
- **Version bump**: `0.2.0` → `0.3.0` in `package.json` and server init

## Test plan

- [ ] `npm install` — installs SDK 1.27.1 without errors
- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] `npm run inspector` — MCP Inspector launches; all three tools visible with titles and annotations
- [ ] Call `generate_unreasonable_thought` — response includes `resource_link` + `structuredContent`
- [ ] Call `branch_thought` with `direction: "opposite"` — response includes `resource_link` + `structuredContent`
- [ ] Call `search_thoughts` — response includes `structuredContent` with `count` and `thoughts` array
- [ ] Call `branch_thought` with invalid `thoughtId` — response has `isError: true`
- [ ] Read `thought://…` resource — returns full thought JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)